### PR TITLE
Fix error with spaces in git path

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,7 @@ meld (on e.g. untracked or modified files).
 Q. How can I abort my changes?
 
 A. Type Control-C at the command line from which you launched `git
-meld-index`.  I'm not sure how one does something similar with vimdiff
-(which is a terminal application): if you know, let me know.
+meld-index`. For `vimdiff` you can type `:cq` to quit with abort.
 
 Q. Why not just use &lt;favourite staging tool&gt;?
 

--- a/bin/git-meld-index-run-merge-tool
+++ b/bin/git-meld-index-run-merge-tool
@@ -3,7 +3,7 @@
 # Based on git-difftool--helper
 
 TOOL_MODE=diff
-. $(git --exec-path)/git-mergetool--lib
+. "$(git --exec-path)/git-mergetool--lib"
 
 if test -n "$GIT_DIFF_TOOL"
 then


### PR DESCRIPTION
Command `git meld-index` causes error if git location contains spaces