### PR TITLE
README.md: Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,39 +32,39 @@ of its use of the `-T` option of the `ln` command).
 
 ## Install
 
-To install via [pipx](https://github.com/pypa/pipx):
-
-```
-pipx install https://github.com/jjlee/git-meld-index/archive/release.zip
-```
-
 To install via [uv](https://github.com/astral-sh/uv):
 
 ```
 uv tool install --from https://github.com/jjlee/git-meld-index/archive/release.zip git-meld-index
 ```
 
-### Installing via pip
+To install via [pipx](https://github.com/pypa/pipx):
 
-To install from the latest release
+```
+pipx install https://github.com/jjlee/git-meld-index/archive/release.zip
+```
+
+### Installing via pip
 
 ```
 pip install https://github.com/jjlee/git-meld-index/archive/release.zip
 ```
 
-To install a specific release:
-
-```
-pip install https://github.com/jjlee/git-meld-index/archive/<release tag here>.zip
-```
+### Installing other versions
 
 To install from the master branch:
 
 ```
-pip install https://github.com/jjlee/git-meld-index/archive/master.zip
+uv tool install https://github.com/jjlee/git-meld-index/archive/master.zip git-meld-index
 ```
 
-### Installing via Git
+To install a specific release:
+
+```
+uv tool install --from https://github.com/jjlee/git-meld-index/archive/<release tag here>.zip git-meld-index
+```
+
+### Running without installation
 
 If you want to avoid installers you can clone the repo and run the
 script directly:
@@ -74,7 +74,6 @@ git clone https://github.com/jjlee/git-meld-index.git
 cd git-meld-index
 env PATH="$PATH":bin python src/git_meld_index.py
 ```
-
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ of its use of the `-T` option of the `ln` command).
 
 ## Install
 
+To install via [pipx](https://github.com/pypa/pipx):
+
+```
+pipx install https://github.com/jjlee/git-meld-index/archive/release.zip
+```
+
+To install via [uv](https://github.com/astral-sh/uv):
+
+```
+uv tool install --from https://github.com/jjlee/git-meld-index/archive/release.zip git-meld-index
+```
+
+### Installing via pip
+
 To install from the latest release
 
 ```
@@ -49,6 +63,8 @@ To install from the master branch:
 ```
 pip install https://github.com/jjlee/git-meld-index/archive/master.zip
 ```
+
+### Installing via Git
 
 If you want to avoid installers you can clone the repo and run the
 script directly:


### PR DESCRIPTION
These days, installing globally via `pip` generally doesn't work. I think `uv` is a very good option for people these days, but `pipx` is also good.

It took me a while to discover that this is surprisingly easy, in spite of the fact that `git-meld-index` doesn't seem to be on PyPi. Hopefully, adding it to the README would save people some time.